### PR TITLE
Improve compatibility with opam-installer

### DIFF
--- a/opaline.ml
+++ b/opaline.ml
@@ -79,6 +79,7 @@ let install_file ?(exec=false) ?(man=false) dir src dst =
 ;;
 
 type param = {
+  name : string;
   libdir : string;
   bindir : string;
   sbindir : string;
@@ -91,11 +92,14 @@ type param = {
   mandir : string;
 }
 
+let get_libdir { name ; libdir } =
+  Filename.concat libdir name
+
 let do_install p ~section ~src ?dst () =
   if section = "lib" then
-    install_file p.libdir src dst
+    install_file (get_libdir p) src dst
   else if section = "libexec" then
-    install_file ~exec:true p.libdir src dst
+    install_file ~exec:true (get_libdir p) src dst
   else if section = "bin" then
     install_file ~exec:true p.bindir src dst
   else if section = "sbin" then
@@ -134,7 +138,8 @@ let get_param prefix name : param =
   if name = "" then raise No_package_name;
   let d x y = if x <> "" then x else filename_concat y in
   {
-    libdir = d !libdir [ prefix ; "lib" ; name ];
+    name ;
+    libdir = d !libdir [ prefix ; "lib" ];
     bindir = d !bindir [ prefix ; "bin" ];
     sbindir = d !sbindir [ prefix ; "sbin" ];
     topleveldir = d !topleveldir [ prefix ; "lib" ; "toplevel" ];

--- a/opaline.ml
+++ b/opaline.ml
@@ -146,9 +146,17 @@ let get_param prefix name : param =
     mandir = d !mandir [ prefix ; "man" ];
   }
 
+(* List of *.install files in current directory *)
+let all_install_files () : string list =
+  () |> Sys.getcwd |> Sys.readdir |> Array.to_list |> List.filter
+  (fun n -> Filename.extension n = ".install")
+
 let _ =
   Arg.parse arg_list (fun s -> files := s::!files) "Usage: opaline [arguments] <install-file>";
-  files := List.rev !files;
+  let files =
+    if !files <> [] then List.rev !files
+    else all_install_files ()
+  in
   List.iter (fun f ->
     let name = if !pkg_name <> "" then !pkg_name else Filename.(chop_extension (basename f)) in
     Format.printf "Processing file %s as %s.@." f name;
@@ -158,5 +166,5 @@ let _ =
      | Variable (_, n, v) -> install_section param n v
      | _ -> raise No_install_file
     ) opam_file.file_contents
-  ) !files
+  ) files
 ;;

--- a/opaline.ml
+++ b/opaline.ml
@@ -40,15 +40,11 @@ let arg_list =
     "-install-cmd", Arg.String (fun s -> install_cmd := s), "Install command";
     "-exec-install-cmd", Arg.String (fun s -> exec_install_cmd := s), "Install command";
   ]
-;; 
-
-let filename_concat l =
-  let rec fc_aux res = function
-  | [] -> res
-  | h::t -> fc_aux (Filename.concat res h) t
-  in
-    fc_aux "" l
 ;;
+
+
+let filename_concat =
+  List.fold_left Filename.concat ""
 
 let install_file ?(exec=false) ?(man=false) dir src dst =
 	let (src, optional) =

--- a/opaline.ml
+++ b/opaline.ml
@@ -137,17 +137,18 @@ let install_section param name files =
 let get_param prefix name : param =
   if name = "" then raise No_package_name;
   let d x y = if x <> "" then x else filename_concat y in
+  let libdir = d !libdir [ prefix ; "lib" ] in
   {
-    name ;
-    libdir = d !libdir [ prefix ; "lib" ];
+    name;
+    libdir;
     bindir = d !bindir [ prefix ; "bin" ];
     sbindir = d !sbindir [ prefix ; "sbin" ];
-    topleveldir = d !topleveldir [ prefix ; "lib" ; "toplevel" ];
+    topleveldir = d !topleveldir [ libdir ; "toplevel" ];
     sharedir = d !sharedir [ prefix ; "share" ; name ];
     share_rootdir = d !share_rootdir [ prefix ; "share" ];
     etcdir = d !etcdir [ prefix ; "etc" ; name ];
     docdir = d !docdir [ prefix ; "doc" ; name ];
-    stublibsdir = d !stublibsdir [ prefix ; "lib" ; "stublibs" ];
+    stublibsdir = d !stublibsdir [ libdir ; "stublibs" ];
     mandir = d !mandir [ prefix ; "man" ];
   }
 


### PR DESCRIPTION
Various improvements:

 -  the `-name` argument is optional, deduced from the `.install` filename if not set;
 -  if no filename is given, defaults to all files in the current directory with a `.install` extension;
 -  do not fail when an optional file is not there.